### PR TITLE
Remove time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ version = "0.2.7"
 
 [dependencies]
 clippy = {version = "~0.0.45", optional = true}
-time = "~0.1.34"
 
 [dev-dependencies]
 rand = "~0.3.14"


### PR DESCRIPTION
Because `std::time::Instant` is now stable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/lru_time_cache/67)
<!-- Reviewable:end -->
