### PR TITLE
Version change to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Lru Time Cache - Change Log
 
+## [0.3.0]
+- Remove dependency on the time crate.
+- Use std::time::Duration in the API
+
 ## [0.2.7]
 - Updated dependencies.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "lru_time_cache"
 readme = "README.md"
 repository = "https://github.com/maidsafe/lru_time_cache"
-version = "0.2.7"
+version = "0.3.0"
 
 [dependencies]
 clippy = {version = "~0.0.45", optional = true}


### PR DESCRIPTION
This is so we can publish the commit that removes the `time` crate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/lru_time_cache/68)
<!-- Reviewable:end -->
