### PR TITLE
Corrected regression tests panicking on an arithmetic operation overflow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ impl<Key, Value> LruCache<Key, Value>
             map: BTreeMap::new(),
             list: VecDeque::new(),
             capacity: capacity,
-            time_to_live: Duration::new(std::u64::MAX, std::u32::MAX),
+            time_to_live: Duration::new(std::u64::MAX, 999_999_999),
         }
     }
 
@@ -217,7 +217,7 @@ impl<Key, Value> LruCache<Key, Value>
     }
 
     fn has_expiry(&self) -> bool {
-        self.time_to_live != Duration::new(std::u64::MAX, std::u32::MAX)
+        self.time_to_live != Duration::new(std::u64::MAX, 999_999_999)
     }
 
     fn expired(&self, key: &Key) -> bool {


### PR DESCRIPTION
This PR corrects the bug I mentioned about [lru_time_cache crate]( https://forum.safenetwork.io/t/how-to-run-a-local-testnet-for-app-development-linux/8855/23?u=tfa) in SAFE Network Forum.

The problem was that the maximum value for the nanos part of a duration is not std::u32::MAX but rather 999_999_999.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/lru_time_cache/69)
<!-- Reviewable:end -->
