### PR TITLE
Various optimization ideas

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,10 @@ where
         Q: Ord,
     {
         self.map.get(key).and_then(|&(ref value, t)| {
-            if self.time_to_live.map_or(false, |ttl| t + ttl < Instant::now()) {
+            if self
+                .time_to_live
+                .map_or(false, |ttl| t + ttl < Instant::now())
+            {
                 return None;
             }
             Some(value)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,10 +249,8 @@ where
         Q: Ord,
     {
         self.map.get(key).and_then(|&(ref value, t)| {
-            if let Some(&ttl) = self.time_to_live.as_ref() {
-                if t + ttl < Instant::now() {
-                    return None;
-                }
+            if self.time_to_live.map_or(false, |ttl| t + ttl < Instant::now()) {
+                return None;
             }
             Some(value)
         })
@@ -281,10 +279,7 @@ where
         Key: Borrow<Q>,
         Q: Ord,
     {
-        self.map.get(key).map_or(false, |v| {
-            self.time_to_live
-                .map_or(true, |ttl| v.1 + ttl >= Instant::now())
-        })
+        self.peek(key).is_some()
     }
 
     /// Returns the size of the cache, i.e. the number of cached non-expired key-value pairs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,6 +365,8 @@ where
             // we have found one item not expired, we must insert it back
             let _ = map.insert(list[i].clone(), val);
             let _ = list.drain(..i);
+        } else if map.is_empty() {
+            list.clear();
         }
     }
 }


### PR DESCRIPTION
This PR is not necessarily meant to be merged as is, it is rather several optimization ideas for the lru_cache.

- `LruCache`:
  - use an `Option<Duration>` for `time_to_live` in order to make the intent clearer than using a static `Duration` value
  - use a `Vec` instead of a `VecDeque` because we always push_back and pop_front => push and drain works well enough I think. Not sure for this one ...
  - in general avoid searching in the map twice (one for `expired` fn and one for actually getting the value)
- iterators (`Iter` and `PeekIter`):
  - use `lru_cache_ttl` for `PeekIter` so it reflects `Iter` logic better
  - match `lru_cache_iter` only once per iteration
  - replace `while let` with simpler `find` and remove the clippy cfg

I couldn't install rustfmt-nightly 0.8.2, so I expect some breaks, I'll fix them later.