### PR TITLE
Yield most recent items first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Lru Time Cache - Change Log
 
+## [Unreleased]
+
+- Update `LruCache::iter()` order - most recently used items will be produced
+  first.
+
 ## [0.8.1]
 - Update to dual license (MIT/BSD)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -663,6 +663,19 @@ mod test {
             assert_eq!(*lru_cache.list.front().unwrap(), 2);
             assert_eq!(*lru_cache.list.back().unwrap(), 1);
         }
+
+        #[test]
+        fn it_yields_items_ordered_by_key() {
+            let mut lru_cache = LruCache::<usize, usize>::with_capacity(4);
+            let _ = lru_cache.insert(2, 2);
+            let _ = lru_cache.insert(0, 0);
+            let _ = lru_cache.insert(3, 3);
+            let _ = lru_cache.insert(1, 1);
+
+            let cached = lru_cache.iter().collect::<Vec<_>>();
+
+            assert_eq!(cached, vec![(&0, &0), (&1, &1), (&2, &2), (&3, &3)]);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Updated iterator traversal order. It used to iterate over the times by their key. Now it will iterate most recently used items first.