### PR TITLE
Ordered peek iter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Lru Time Cache - Change Log
 
+## [Unreleased]
+
+- Update `LruCache::peek_iter()` order - most recently used items will be
+  produced first.
+
 ## [0.9.0]
 
 - API to get expired or pushed out items from the LRU

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,206 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! Misc LRU cache iterators.
+
+#[cfg(feature = "fake_clock")]
+use fake_clock::FakeClock as Instant;
+use std::collections::{btree_map, BTreeMap, VecDeque};
+use std::time::Duration;
+#[cfg(not(feature = "fake_clock"))]
+use std::time::Instant;
+
+/// An iterator over an `LruCache`'s entries that updates the timestamps as values are traversed.
+/// Values are produced in the most recently used order.
+pub struct Iter<'a, Key, Value> {
+    /// Reference to the iterated cache.
+    map: &'a mut BTreeMap<Key, (Value, Instant)>,
+    /// Ordered cache entry keys where the least recently used items are first.
+    list: &'a mut VecDeque<Key>,
+    lru_cache_ttl: Option<Duration>,
+    /// Index in `list` of the previously used item.
+    item_index: usize,
+}
+
+impl<'a, Key, Value> Iter<'a, Key, Value>
+where
+    Key: Ord,
+{
+    #[doc(hidden)]
+    pub fn new(
+        map: &'a mut BTreeMap<Key, (Value, Instant)>,
+        list: &'a mut VecDeque<Key>,
+        lru_cache_ttl: Option<Duration>,
+    ) -> Self {
+        let item_index = list.len();
+        Self {
+            map,
+            list,
+            lru_cache_ttl,
+            item_index,
+        }
+    }
+
+    /// Returns next unexpired item in the cache or `None` if no such items.
+    /// Expired items are removed from the cache.
+    fn next_unexpired(&mut self, now: Instant) -> Option<Key> {
+        loop {
+            self.item_index = self.item_index.checked_sub(1)?;
+            let key = self.list.remove(self.item_index)?;
+            let value = self.map.get(&key)?;
+
+            if let Some(ttl) = self.lru_cache_ttl {
+                if value.1 + ttl > now {
+                    return Some(key);
+                } else {
+                    let _ = self.map.remove(&key);
+                }
+            } else {
+                return Some(key);
+            }
+        }
+    }
+}
+
+impl<'a, Key, Value> Iterator for Iter<'a, Key, Value>
+where
+    Key: Ord + Clone,
+{
+    type Item = (&'a Key, &'a Value);
+
+    /// Returns the next element in the cache and moves it to the top of the cache.
+    /// The most recently used items are yield first.
+    #[allow(unsafe_code)]
+    fn next(&mut self) -> Option<(&'a Key, &'a Value)> {
+        let now = Instant::now();
+        let key = self.next_unexpired(now)?;
+        self.list.push_back(key);
+        let key = self.list.back()?;
+        let mut value = self.map.get_mut(&key)?;
+        value.1 = now;
+
+        unsafe {
+            let key = std::mem::transmute::<&Key, &'a Key>(key);
+            let value = std::mem::transmute::<&Value, &'a Value>(&value.0);
+            Some((key, value))
+        }
+    }
+}
+
+/// Entry produced by `NotifyIter` that might be still valid or expired.
+pub enum TimedEntry<'a, Key: 'a, Value: 'a> {
+    /// Entry has not yet expired.
+    Valid(&'a Key, &'a Value),
+    /// Entry got expired and was evicted from the cache.
+    Expired(Key, Value),
+}
+
+/// Much like `Iter` except will produce expired entries too where `Iter` silently drops them.
+pub struct NotifyIter<'a, Key, Value> {
+    /// Reference to the iterated cache.
+    map: &'a mut BTreeMap<Key, (Value, Instant)>,
+    /// Ordered cache entry keys where the least recently used items are first.
+    list: &'a mut VecDeque<Key>,
+    lru_cache_ttl: Option<Duration>,
+    /// Index in `list` of the previously used item.
+    item_index: usize,
+}
+
+impl<'a, Key, Value> NotifyIter<'a, Key, Value>
+where
+    Key: Ord + Clone,
+{
+    #[doc(hidden)]
+    pub fn new(
+        map: &'a mut BTreeMap<Key, (Value, Instant)>,
+        list: &'a mut VecDeque<Key>,
+        lru_cache_ttl: Option<Duration>,
+    ) -> Self {
+        let item_index = list.len();
+        Self {
+            map,
+            list,
+            lru_cache_ttl,
+            item_index,
+        }
+    }
+}
+
+impl<'a, Key, Value> Iterator for NotifyIter<'a, Key, Value>
+where
+    Key: Ord + Clone,
+{
+    type Item = TimedEntry<'a, Key, Value>;
+
+    /// Returns the next element in the cache and moves it to the top of the cache.
+    /// The most recently used items are yield first.
+    #[allow(unsafe_code)]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.item_index = self.item_index.checked_sub(1)?;
+        let key = self.list.remove(self.item_index)?;
+        let mut value = self.map.get_mut(&key)?;
+        let now = Instant::now();
+
+        if let Some(ttl) = self.lru_cache_ttl {
+            if value.1 + ttl <= now {
+                let value = self.map.remove(&key)?;
+                return Some(TimedEntry::Expired(key, value.0));
+            }
+        }
+
+        self.list.push_back(key);
+        let key = self.list.back()?;
+        value.1 = now;
+        unsafe {
+            let key = std::mem::transmute::<&Key, &'a Key>(key);
+            let value = std::mem::transmute::<&Value, &'a Value>(&value.0);
+            Some(TimedEntry::Valid(key, value))
+        }
+    }
+}
+
+/// An iterator over an `LruCache`'s entries that does not modify the timestamp.
+pub struct PeekIter<'a, Key, Value> {
+    map_iter: btree_map::Iter<'a, Key, (Value, Instant)>,
+    lru_cache_ttl: Option<Duration>,
+}
+
+impl<'a, Key, Value> PeekIter<'a, Key, Value>
+where
+    Key: Ord + Clone,
+{
+    #[doc(hidden)]
+    pub fn new(
+        map_iter: btree_map::Iter<'a, Key, (Value, Instant)>,
+        lru_cache_ttl: Option<Duration>,
+    ) -> Self {
+        Self {
+            map_iter,
+            lru_cache_ttl,
+        }
+    }
+}
+
+impl<'a, Key, Value> Iterator for PeekIter<'a, Key, Value>
+where
+    Key: Ord + Clone,
+{
+    type Item = (&'a Key, &'a Value);
+
+    fn next(&mut self) -> Option<(&'a Key, &'a Value)> {
+        let now = Instant::now();
+        let not_expired = match self.lru_cache_ttl {
+            Some(ttl) => self
+                .map_iter
+                .find(|&(_, &(_, instant))| instant + ttl > now),
+            None => self.map_iter.next(),
+        };
+        not_expired.map(|(key, &(ref value, _))| (key, value))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,7 +349,7 @@ where
 
     /// Returns an iterator over all entries that does not modify the timestamps.
     pub fn peek_iter(&self) -> PeekIter<'_, Key, Value> {
-        PeekIter::new(self.map.iter(), self.time_to_live)
+        PeekIter::new(&self.map, &self.list, self.time_to_live)
     }
 
     // Move `key` in the ordered list to the last
@@ -806,7 +806,7 @@ mod test {
         use super::*;
 
         #[test]
-        fn it_yields_cached_entries() {
+        fn it_yields_cached_entries_in_most_recently_used_order() {
             let time_to_live = Duration::from_millis(500);
             let mut lru_cache = super::LruCache::<usize, usize>::with_expiry_duration(time_to_live);
 
@@ -815,7 +815,7 @@ mod test {
             let _ = lru_cache.insert(3, 3);
 
             assert_eq!(
-                vec![(&1, &1), (&2, &2), (&3, &3)],
+                vec![(&3, &3), (&2, &2), (&1, &1)],
                 lru_cache.peek_iter().collect::<Vec<_>>()
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,11 +86,14 @@
 #[cfg(feature = "fake_clock")]
 use fake_clock::FakeClock as Instant;
 use std::borrow::Borrow;
-use std::collections::{btree_map, BTreeMap, VecDeque};
+use std::collections::{BTreeMap, VecDeque};
 use std::time::Duration;
 #[cfg(not(feature = "fake_clock"))]
 use std::time::Instant;
 use std::usize;
+
+mod iter;
+pub use crate::iter::{Iter, NotifyIter, PeekIter, TimedEntry};
 
 /// A view into a single entry in an LRU cache, which may either be vacant or occupied.
 pub enum Entry<'a, Key: 'a, Value: 'a> {
@@ -109,144 +112,6 @@ pub struct VacantEntry<'a, Key, Value> {
 /// An occupied Entry.
 pub struct OccupiedEntry<'a, Value> {
     value: &'a mut Value,
-}
-
-/// An iterator over an `LruCache`'s entries that updates the timestamps as values are traversed.
-/// Values are produced in the most recently used order.
-pub struct Iter<'a, Key, Value> {
-    /// Reference to the iterated cache.
-    map: &'a mut BTreeMap<Key, (Value, Instant)>,
-    /// Ordered cache entry keys where the least recently used items are first.
-    list: &'a mut VecDeque<Key>,
-    lru_cache_ttl: Option<Duration>,
-    /// Index in `list` of the previously used item.
-    item_index: usize,
-}
-
-impl<'a, Key, Value> Iter<'a, Key, Value>
-where
-    Key: Ord,
-{
-    /// Returns next unexpired item in the cache or `None` if no such items.
-    /// Expired items are removed from the cache.
-    fn next_unexpired(&mut self, now: Instant) -> Option<Key> {
-        loop {
-            self.item_index = self.item_index.checked_sub(1)?;
-            let key = self.list.remove(self.item_index)?;
-            let value = self.map.get(&key)?;
-
-            if let Some(ttl) = self.lru_cache_ttl {
-                if value.1 + ttl > now {
-                    return Some(key);
-                } else {
-                    let _ = self.map.remove(&key);
-                }
-            } else {
-                return Some(key);
-            }
-        }
-    }
-}
-
-impl<'a, Key, Value> Iterator for Iter<'a, Key, Value>
-where
-    Key: Ord + Clone,
-{
-    type Item = (&'a Key, &'a Value);
-
-    /// Returns the next element in the cache and moves it to the top of the cache.
-    /// The most recently used items are yield first.
-    #[allow(unsafe_code)]
-    fn next(&mut self) -> Option<(&'a Key, &'a Value)> {
-        let now = Instant::now();
-        let key = self.next_unexpired(now)?;
-        self.list.push_back(key);
-        let key = self.list.back()?;
-        let mut value = self.map.get_mut(&key)?;
-        value.1 = now;
-
-        unsafe {
-            let key = std::mem::transmute::<&Key, &'a Key>(key);
-            let value = std::mem::transmute::<&Value, &'a Value>(&value.0);
-            Some((key, value))
-        }
-    }
-}
-
-/// Entry produced by `NotifyIter` that might be still valid or expired.
-pub enum TimedEntry<'a, Key: 'a, Value: 'a> {
-    /// Entry has not yet expired.
-    Valid(&'a Key, &'a Value),
-    /// Entry got expired and was evicted from the cache.
-    Expired(Key, Value),
-}
-
-/// Much like `Iter` except will produce expired entries too where `Iter` silently drops them.
-pub struct NotifyIter<'a, Key, Value> {
-    /// Reference to the iterated cache.
-    map: &'a mut BTreeMap<Key, (Value, Instant)>,
-    /// Ordered cache entry keys where the least recently used items are first.
-    list: &'a mut VecDeque<Key>,
-    lru_cache_ttl: Option<Duration>,
-    /// Index in `list` of the previously used item.
-    item_index: usize,
-}
-
-impl<'a, Key, Value> Iterator for NotifyIter<'a, Key, Value>
-where
-    Key: Ord + Clone,
-{
-    type Item = TimedEntry<'a, Key, Value>;
-
-    /// Returns the next element in the cache and moves it to the top of the cache.
-    /// The most recently used items are yield first.
-    #[allow(unsafe_code)]
-    fn next(&mut self) -> Option<Self::Item> {
-        self.item_index = self.item_index.checked_sub(1)?;
-        let key = self.list.remove(self.item_index)?;
-        let mut value = self.map.get_mut(&key)?;
-        let now = Instant::now();
-
-        if let Some(ttl) = self.lru_cache_ttl {
-            if value.1 + ttl <= now {
-                let value = self.map.remove(&key)?;
-                return Some(TimedEntry::Expired(key, value.0));
-            }
-        }
-
-        self.list.push_back(key);
-        let key = self.list.back()?;
-        value.1 = now;
-        unsafe {
-            let key = std::mem::transmute::<&Key, &'a Key>(key);
-            let value = std::mem::transmute::<&Value, &'a Value>(&value.0);
-            Some(TimedEntry::Valid(key, value))
-        }
-    }
-}
-
-/// An iterator over an `LruCache`'s entries that does not modify the timestamp.
-pub struct PeekIter<'a, Key, Value> {
-    map_iter: btree_map::Iter<'a, Key, (Value, Instant)>,
-    lru_cache_ttl: Option<Duration>,
-}
-
-impl<'a, Key, Value> Iterator for PeekIter<'a, Key, Value>
-where
-    Key: Ord + Clone,
-{
-    type Item = (&'a Key, &'a Value);
-
-    fn next(&mut self) -> Option<(&'a Key, &'a Value)> {
-        let now = Instant::now();
-        let not_expired = match self.lru_cache_ttl {
-            Some(ttl) => self
-                .map_iter
-                .find(|&(_, &(_, instant))| instant + ttl > now),
-            None => self.map_iter.next(),
-        };
-        not_expired.map(|(key, &(ref value, _))| (key, value))
-    }
 }
 
 /// Implementation of [LRU cache](index.html#least-recently-used-lru-cache).
@@ -471,12 +336,7 @@ where
     ///
     /// Also, evicts and returns expired entries.
     pub fn notify_iter(&mut self) -> NotifyIter<'_, Key, Value> {
-        NotifyIter {
-            item_index: self.list.len(),
-            map: &mut self.map,
-            list: &mut self.list,
-            lru_cache_ttl: self.time_to_live,
-        }
+        NotifyIter::new(&mut self.map, &mut self.list, self.time_to_live)
     }
 
     /// Returns an iterator over all entries that updates the timestamps as values are
@@ -484,21 +344,12 @@ where
     /// Values are produced in the most recently used order.
     pub fn iter(&mut self) -> Iter<'_, Key, Value> {
         let _ = self.remove_expired();
-
-        Iter {
-            item_index: self.list.len(),
-            map: &mut self.map,
-            list: &mut self.list,
-            lru_cache_ttl: self.time_to_live,
-        }
+        Iter::new(&mut self.map, &mut self.list, self.time_to_live)
     }
 
     /// Returns an iterator over all entries that does not modify the timestamps.
     pub fn peek_iter(&self) -> PeekIter<'_, Key, Value> {
-        PeekIter {
-            map_iter: self.map.iter(),
-            lru_cache_ttl: self.time_to_live,
-        }
+        PeekIter::new(self.map.iter(), self.time_to_live)
     }
 
     // Move `key` in the ordered list to the last


### PR DESCRIPTION
Update peek_iter() to yield most recently used items first. This is useful when we are trying to serialize the cache, etc.

Currently, peek_iter() yields items sorted by their key which does not make a lot of sense in LRU cache.