### PR TITLE
bugfix: fix edge cases related to time atomicity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,8 +445,9 @@ where
 impl<'a, Key: Ord + Clone, Value> VacantEntry<'a, Key, Value> {
     /// Inserts a value
     pub fn insert(self, value: Value) -> &'a mut Value {
-        let _ = self.cache.insert(self.key.clone(), value);
-        self.cache.get_mut(&self.key).expect("key not found")
+        let now = Instant::now();
+        let _ = self.cache.do_notify_insert(self.key.clone(), value, now);
+        self.cache.do_notify_get_mut(&self.key, now).0.expect("key not found")
     }
 }
 


### PR DESCRIPTION
These changes aim to make it so that calls to the public API
operate over the cache using a single Instant of time rather than
calling Instant::now() at several unique points in time during the
synchronous execution of the function.

The former execution model lead to potential bugs, notably in functions
like entry() as brought up in #122, especially on targets with less processing
power or under heavy load.

This also reduces the number of system calls that need to be made which
may improve performance for some use cases.