### PR TITLE
Rebase to make it work with Rust stable 1.41

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -877,7 +877,7 @@ mod test {
                 .map
                 .values()
                 .map(|(_, updated_at)| updated_at)
-                .nth(0)
+                .next()
                 .unwrap();
 
             let _ = lru_cache.peek_iter().collect::<Vec<_>>();
@@ -886,7 +886,7 @@ mod test {
                 .map
                 .values()
                 .map(|(_, updated_at)| updated_at)
-                .nth(0)
+                .next()
                 .unwrap();
             assert_eq!(real_time, expected_time);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,8 +445,9 @@ where
 impl<'a, Key: Ord + Clone, Value> VacantEntry<'a, Key, Value> {
     /// Inserts a value
     pub fn insert(self, value: Value) -> &'a mut Value {
-        let _ = self.cache.insert(self.key.clone(), value);
-        self.cache.get_mut(&self.key).expect("key not found")
+        let now = Instant::now();
+        let _ = self.cache.do_notify_insert(self.key.clone(), value, now);
+        self.cache.do_notify_get_mut(&self.key, now).0.expect("key not found")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,6 @@
     missing_docs,
     non_shorthand_field_patterns,
     overflowing_literals,
-    plugin_as_library,
     stable_features,
     unconditional_recursion,
     unknown_lints,
@@ -447,7 +446,10 @@ impl<'a, Key: Ord + Clone, Value> VacantEntry<'a, Key, Value> {
     pub fn insert(self, value: Value) -> &'a mut Value {
         let now = Instant::now();
         let _ = self.cache.do_notify_insert(self.key.clone(), value, now);
-        self.cache.do_notify_get_mut(&self.key, now).0.expect("key not found")
+        self.cache
+            .do_notify_get_mut(&self.key, now)
+            .0
+            .expect("key not found")
     }
 }
 


### PR DESCRIPTION
@S-Coyle since it looks like you're picking up maintenance work of this crate, I was wonder if you could merge this change. I've incorporated @povilasb's PR #123 here fixing the code formatting that's making his PR fail. I've also removed the mention to `plugin_as_library` that makes it not compile in Rust stable.